### PR TITLE
fix autobox problem on CockroachDB (#1175)

### DIFF
--- a/core/src/main/java/org/jobrunr/utils/reflection/autobox/BooleanTypeAutoboxer.java
+++ b/core/src/main/java/org/jobrunr/utils/reflection/autobox/BooleanTypeAutoboxer.java
@@ -18,6 +18,8 @@ public class BooleanTypeAutoboxer implements TypeAutoboxer<Boolean> {
             return cast(!BigDecimal.ZERO.equals(value));
         } else if (value instanceof Integer) {
             return cast(((Integer) value) != 0);
+        } else if (value instanceof Long) {
+            return cast(((Long) value) != 0);
         }
         throw new UnsupportedOperationException(String.format("Cannot autobox %s of type %s to %s", value, value.getClass().getName(), Boolean.class.getName()));
     }


### PR DESCRIPTION
CockroachDB returns an object of type Long to represent `jobrunr_backgroundjobservers.running` which is declared as a SQL int.

This results in an autobox exception which prevents jobrunr from starting.

Note that changing the column definition to `bool` is an alternative workaround.


